### PR TITLE
Update data types

### DIFF
--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -228,6 +228,57 @@ class test_core(unittest.TestCase):
             test.reshape(2, use_turns = [1], store_time = True)
 
 
+    def test_multiplication(self):
+
+        test = core._function(2, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test *= 5
+        self.assertEqual(test, 10, msg='Single value in place multiplication '
+                                         + 'incorrect')
+
+        test = core._function(2, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        self.assertEqual(test2, 4, msg='Single value multiplication '
+                                         + 'incorrect')
+        
+        
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test *= 2
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by turn in place multiplication " +
+                                          "incorrect")
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn multiplication incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test *= 2
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by time in place multiplication "
+                                          + "incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time multiplication incorrect")
+
+
     def test_addition(self):
 
         test = core._function(1, data_type = {'timebase': 'single'},

--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -85,34 +85,149 @@ class test_core(unittest.TestCase):
                                       msg='Type incorrect after copying')
 
 
-    def test_reshape(self):
+    def test_reshape_basic(self):
 
-        test1 = core._function(np.array([[[1, 2, 3], [1, 2, 3]]]),
+        ############
+        #TIME BASED#
+        ############
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]]]),
                            data_type={'timebase': 'by_time'},
                            interpolation='linear')
-        test2 = test1.reshape(1, [1.5])
-        self.assertEqual(test2, 1.5,
+        test = test.reshape(1, [1.5], [1])
+        self.assertEqual(test, 1.5,
                                  msg='Interpolation not computed correctly')
-        self.assertIsInstance(test2, core._function,
+        self.assertIsInstance(test, core._function,
                                   msg='Type incorrect after reshape')
-        self.assertEqual(test2.timebase, 'interpolated',
+        self.assertEqual(test.timebase, 'interpolated',
                          msg = 'After reshape timebase should be interpolated')
 
-
-        test3 = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
                                          [[1, 2, 3], [4, 5, 6]]]),
                            data_type={'timebase': 'by_time'},
                            interpolation='linear')
-        test4 = test3.reshape(2, [1.5])
+        test = test.reshape(2, [1.5], [1])
 
-        self.assertEqual(test4[0][0], 1.5,
+        self.assertEqual(test[0][0], 1.5,
                                  msg='Interpolation not computed correctly')
-        self.assertEqual(test4[1][0], 4.5,
+        self.assertEqual(test[1][0], 4.5,
                                  msg='Interpolation not computed correctly')
-        self.assertIsInstance(test4, core._function,
+        self.assertIsInstance(test, core._function,
                                   msg='Type incorrect after reshape')
-        self.assertEqual(test4.timebase, 'interpolated',
+        self.assertEqual(test.timebase, 'interpolated',
                          msg = 'After reshape timebase should be interpolated')
+
+        ############
+        #TURN BASED#
+        ############
+        test = core._function(np.array([[1, 2, 3, 1, 2, 3]]),
+                           data_type={'timebase': 'by_turn'},
+                           interpolation='linear')
+        test = test.reshape(1, [1.5], use_turns = [1])
+        self.assertEqual(test, 2, msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        test = core._function(np.array([[1, 2, 3, 1, 2, 3],
+                                          [1, 2, 3, 4, 5, 6]]),
+                            data_type={'timebase': 'by_turn'},
+                            interpolation='linear')
+        test = test.reshape(2, use_time = [1.5, 2.5], use_turns = [1, 3])
+
+        self.assertEqual(test[0][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[0][1], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][1], 4,
+                                  msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        ###############
+        #SINGLE VALUED#
+        ###############
+        test = core._function(np.array([1]),
+                           data_type={'timebase': 'single'},
+                           interpolation='linear')
+        test = test.reshape(1, [1.5], use_turns = [1])
+        self.assertEqual(test, 1, msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        test = core._function(np.array([1, 2, 3]),
+                            data_type={'timebase': 'single'},
+                            interpolation='linear')
+        test = test.reshape(3, use_time = [1.5, 2.5], use_turns = [1, 3])
+
+        self.assertEqual(test[0][0], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[0][1], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][1], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[2][0], 3,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[2][1], 3,
+                                  msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+
+    def test_reshape_store_time(self):
+
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
+                                          [[1, 2, 3], [4, 5, 6]]]),
+                            data_type={'timebase': 'by_time'},
+                            interpolation='linear')
+        test = test.reshape(2, [1.5], store_time = True)
+
+        self.assertEqual(test.shape, (2, 2, 1),
+                             msg = 'The reshaped array has the wrong shape')
+        self.assertEqual(test[0,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[1,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[0,1,0], 1.5,
+                                     msg = 'The interpolation is incorrect')
+        self.assertEqual(test[1,1,0], 4.5,
+                                     msg = 'The interpolation is incorrect')
+
+        test = core._function(np.array([1, 2]),
+                              data_type={'timebase': 'single'},
+                              interpolation='linear')
+        test = test.reshape(2, [1.5], store_time = True)
+
+        self.assertEqual(test.shape, (2, 2, 1),
+                             msg = 'The reshaped array has the wrong shape')
+        self.assertEqual(test[0,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[1,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[0,1,0], 1,
+                                     msg = 'The interpolation is incorrect')
+        self.assertEqual(test[1,1,0], 2,
+                                     msg = 'The interpolation is incorrect')
+
+        test = core._function.zeros([2, 3], data_type={'timebase':
+                                                           'by_turn'})
+        with self.assertRaises(exceptions.InputError, \
+                               msg='store_time should raise an InputError '
+                                   +'for a function defined by_turn'):
+            test.reshape(2, use_turns = [1], store_time = True)
+
+
+
 
 if __name__ == '__main__':
 

--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -66,14 +66,53 @@ class test_core(unittest.TestCase):
     def test_slicing(self):
 
         test = core._function.zeros(10, data_type={'timebase': 'fake'})
+        sliced = test[:5]
 
-        slice1 = test[:5]
-        slice2 = test[5:]
+        self.assertEqual(sliced.data_type['timebase'], 'fake',
+                             msg='sliced data_type not copied correctly')
+        self.assertIsInstance(sliced, core._function,
+                              msg='Type incorrect after slicing')
 
-        self.assertEqual(slice1.data_type['timebase'], 'fake1',
-                             msg='slice1 data_type not copied correctly')
-        self.assertEqual(slice2.data_type['timebase'], 'fake',
-                             msg='slice1 data_type not copied correctly')
+
+    def test_copy(self):
+
+        test = core._function.zeros(10, data_type={'timebase': 'fake'})
+        copied = test.copy()
+
+        self.assertEqual(copied.data_type['timebase'], 'fake',
+                             msg='copied data_type not copied correctly')
+        self.assertIsInstance(copied, core._function,
+                                      msg='Type incorrect after copying')
+
+
+    def test_reshape(self):
+
+        test1 = core._function(np.array([[[1, 2, 3], [1, 2, 3]]]),
+                           data_type={'timebase': 'by_time'},
+                           interpolation='linear')
+        test2 = test1.reshape(1, [1.5])
+        self.assertEqual(test2, 1.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertIsInstance(test2, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test2.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+
+        test3 = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
+                                         [[1, 2, 3], [4, 5, 6]]]),
+                           data_type={'timebase': 'by_time'},
+                           interpolation='linear')
+        test4 = test3.reshape(2, [1.5])
+
+        self.assertEqual(test4[0][0], 1.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertEqual(test4[1][0], 4.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertIsInstance(test4, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test4.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
 
 if __name__ == '__main__':
 

--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -17,6 +17,7 @@ Test dataypes._core.py
 import sys
 import unittest
 import numpy as np
+import numpy.testing as npTest
 import os
 
 this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
@@ -227,6 +228,51 @@ class test_core(unittest.TestCase):
             test.reshape(2, use_turns = [1], store_time = True)
 
 
+    def test_addition(self):
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test += 5
+        self.assertEqual(test, 6, msg='Single value in place addition '
+                                         + 'incorrect')
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        self.assertEqual(test2, 2, msg='Single value addition '
+                                         + 'incorrect')
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test += 5
+        compare = [[6, 7, 8], [9, 10, 11]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by turn in place addition incorrect")
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        compare = [[2, 3, 4], [5, 6, 7]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn addition incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test += 5
+        compare = [[[1, 2, 3], [9, 10, 11]]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by time in place addition incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        compare = [[[1, 2, 3], [5, 6, 7]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time addition incorrect")
 
 
 if __name__ == '__main__':

--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -241,8 +241,9 @@ class test_core(unittest.TestCase):
         test2 = test * 2
         self.assertEqual(test2, 4, msg='Single value multiplication '
                                          + 'incorrect')
-        
-        
+        test2 = 2 * test
+        self.assertEqual(test2, 4, msg='Single value rmultiplication '
+                                         + 'incorrect')
 
         test = core._function([[1, 2, 3], [4, 5, 6]],
                               data_type = {'timebase': 'by_turn'},
@@ -260,6 +261,10 @@ class test_core(unittest.TestCase):
         compare = [[2, 4, 6], [8, 10, 12]]
         npTest.assert_array_equal(test2, compare,
                               err_msg = "by turn multiplication incorrect")
+        test2 = 2 * test
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn rmultiplication incorrect")
 
         test = core._function([[[1, 2, 3], [4, 5, 6]]],
                               data_type = {'timebase': 'by_time'},
@@ -277,6 +282,10 @@ class test_core(unittest.TestCase):
         compare = [[[1, 2, 3], [8, 10, 12]]]
         npTest.assert_array_equal(test2, compare,
                               err_msg = "by time multiplication incorrect")
+        test2 = 2 * test
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time rmultiplication incorrect")
 
 
     def test_addition(self):
@@ -291,6 +300,9 @@ class test_core(unittest.TestCase):
                               interpolation = 'linear')
         test2 = test + 1
         self.assertEqual(test2, 2, msg='Single value addition '
+                                         + 'incorrect')
+        test2 = 1 + test
+        self.assertEqual(test2, 2, msg='Single value raddition '
                                          + 'incorrect')
 
         test = core._function([[1, 2, 3], [4, 5, 6]],
@@ -308,6 +320,10 @@ class test_core(unittest.TestCase):
         compare = [[2, 3, 4], [5, 6, 7]]
         npTest.assert_array_equal(test2, compare,
                               err_msg = "by turn addition incorrect")
+        test2 = 1 + test
+        compare = [[2, 3, 4], [5, 6, 7]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn raddition incorrect")
 
         test = core._function([[[1, 2, 3], [4, 5, 6]]],
                               data_type = {'timebase': 'by_time'},
@@ -324,6 +340,10 @@ class test_core(unittest.TestCase):
         compare = [[[1, 2, 3], [5, 6, 7]]]
         npTest.assert_array_equal(test2, compare,
                               err_msg = "by time addition incorrect")
+        test2 = 1 + test
+        compare = [[[1, 2, 3], [5, 6, 7]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time raddition incorrect")
 
 
 if __name__ == '__main__':

--- a/__TESTS/unittests/datatypes/core.py
+++ b/__TESTS/unittests/datatypes/core.py
@@ -1,0 +1,80 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import os
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+import blond_common.datatypes._core as core
+from blond_common.devtools import exceptions
+
+class test_core(unittest.TestCase):
+
+    def test_creation(self):
+
+        core._function(np.array([1, 2, 3]), data_type = {},
+                                       interpolation = 'linear')
+        core._function(np.array([[1, 2, 3], [2, 3, 4]]), data_type = {})
+        core._function(np.zeros([3, 2, 10]), data_type = {})
+        core._function(np.array([[1, 2, 3], [2, 3]]), data_type = {})
+
+
+    def test_zeros(self):
+
+        test = core._function.zeros([3, 3])
+        self.assertEqual(len(test.shape), 2,
+                                 'length of test.shape should be 2')
+        self.assertEqual(test.shape[0], 3,
+                                 'first element of shape should be 3')
+        self.assertEqual(test.shape[1], 3,
+                                 'second element of shape should be 3')
+
+        self.assertIsNone(test.timebase, msg='timebase should be None')
+
+        test = core._function.zeros([3, 3], data_type = {'timebase': 'test'})
+        self.assertEqual(test.timebase, 'test',
+                                 msg='timebase has not been correctly set')
+
+        with self.assertRaises(exceptions.InputDataError, \
+                               msg='Passing an invalid parameter should ' \
+                               + 'raise an InputDataError'):
+
+            test = core._function.zeros([3, 3], data_type = {'fake_parameter':
+                                                                 'test'})
+
+    def test_slicing(self):
+
+        test = core._function.zeros(10, data_type={'timebase': 'fake'})
+
+        slice1 = test[:5]
+        slice2 = test[5:]
+
+        self.assertEqual(slice1.data_type['timebase'], 'fake1',
+                             msg='slice1 data_type not copied correctly')
+        self.assertEqual(slice2.data_type['timebase'], 'fake',
+                             msg='slice1 data_type not copied correctly')
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -46,13 +46,14 @@ class _function(np.ndarray):
         the array, currently only 'linear' has been implemented
     """
     
-    def __new__(cls, input_array, data_type=None, interpolation = None):
+    def __new__(cls, input_array, data_type=None, interpolation = None,
+                dtype = None):
         
         if data_type is None:
             raise excpt.InputError("data_type must be specified")
 
         try:
-            obj = np.asarray(input_array).view(cls)
+            obj = np.asarray(input_array, dtype=dtype).view(cls)
         except ValueError:
             raise excpt.InputError("Function components could not be " \
                                         + "correctly coerced into ndarray, " \
@@ -95,6 +96,16 @@ class _function(np.ndarray):
 
     __rmul__ = __mul__
     __rimul__ = __imul__
+
+    def __truediv__(self, other):
+        print("in truediv")
+        return self._operate(other, np.true_divide, inPlace = False)
+
+    def __itruediv__(self, other):
+        self._operate(other, np.true_divide, inPlace = True)
+        return self
+
+    # __rtruediv__ = __truediv__
 
     def _operate(self, other, operation, inPlace = False):
         if isinstance(other, self.__class__):
@@ -139,11 +150,11 @@ class _function(np.ndarray):
 
         newArray = self.copy()
         if self.timebase == 'by_time':
-            newArray[:,1,:] = operation(self[:,1,:], other)
+            newArray[:,1,:] = operation(self[:,1,:], other, casting = 'unsafe')
         elif self.timebase == 'single':
-            newArray[()] = operation(self, other)
+            newArray[()] = operation(self, other, casting = 'unsafe')
         else:
-            newArray[:] = operation(self, other)
+            newArray[:] = operation(self, other, casting = 'unsafe')
         return newArray
 
 

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -226,12 +226,15 @@ class _function(np.ndarray):
             If the funtion has fewer turns of data available than required
             for the use_turns bassed, a DataDefinitionError is raised.
         """
+
         if n_sections > 1 and self.shape[0] == 1:
+
             warnings.warn("multi-section required, but "
                           + str(self.__class__.__name__) + " function is single"
                           + " section, expanding to match n_sections")
 
         elif n_sections != self.shape[0]:
+
             raise excpt.DataDefinitionError("n_sections (" \
                                                  + str(n_sections) \
                                                  + ") does not match function "
@@ -295,7 +298,7 @@ class _function(np.ndarray):
         if self.interpolation == 'linear':
             return self._interpolate_linear(section, use_time)
         else:
-            raise RuntimeError("Invalid interpolation requested")
+            raise NotImplementedError("Only linear interpolation implemented")
 
 
     def _interpolate_linear(self, section, use_time):

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -122,6 +122,7 @@ class _function(np.ndarray):
                     raise excpt.InputDataError("data_type has "
                                                     + "unrecognised option '"
                                                     + str(d) + "'")
+        return
 
     @property
     def timebase(self):
@@ -359,7 +360,11 @@ class _function(np.ndarray):
             elif self.timebase == 'by_time':
                     newArray[s] = self._interpolate(s, use_time)
 
-        return newArray.view(self.__class__)
+        newArray = newArray.view(self.__class__)
+        newArray.data_type = self.data_type
+        newArray.timebase = 'interpolated'
+
+        return newArray
 
 
 ###############################################

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -1,5 +1,6 @@
 # General imports
 import numpy as np
+import numbers
 import sys
 import os
 import warnings
@@ -73,6 +74,51 @@ class _function(np.ndarray):
             return
 
         self.data_type = getattr(obj, 'data_type', None)
+
+
+    def __add__(self, other):
+        return self._add(other, inPlace = False)
+
+
+    def _add(self, other, inPlace = False):
+        if isinstance(other, self.__class__):
+            self._check_data_and_type(other)
+            newArray = self._operate_equivalent_functions(other, np.add)
+            if not inPlace:
+                return newArray
+
+
+    def _operate_equivalent_functions(self, other, operation):
+        newArray = self.copy()
+        if self.timebase == 'by_time':
+            newArray[:,1,:] = operation(self[:,1,:], other[:,1,:])
+        else:
+            newArray[:] = operation(self, other)
+
+        return newArray
+
+
+    def _operate_other(self, other, operation):
+        if isinstance(other, numbers.Number):
+            return self._operate_equivalent_functions(other, operation)
+
+
+    def _type_check(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError("Datatypes should be the same, but they are "
+                            + f"{self.__class__} and {other.__class__}.")
+
+
+    def _data_check(self, other):
+        if self.data_type != other.data_type:
+            raise TypeError("Datatypes should have the same `data_type` dict "
+                            +f"but they are {self.data_type} and "
+                            +f"{other.data_type}")
+
+
+    def _check_data_and_type(self, other):
+        self._type_check(other)
+        self._data_check(other)
 
 
     @classmethod

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -98,14 +98,11 @@ class _function(np.ndarray):
     __rimul__ = __imul__
 
     def __truediv__(self, other):
-        print("in truediv")
         return self._operate(other, np.true_divide, inPlace = False)
 
     def __itruediv__(self, other):
         self._operate(other, np.true_divide, inPlace = True)
         return self
-
-    # __rtruediv__ = __truediv__
 
     def _operate(self, other, operation, inPlace = False):
         if isinstance(other, self.__class__):

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -104,6 +104,8 @@ class _function(np.ndarray):
         if inPlace:
             if self.timebase == 'by_time':
                 self[:,1,:] = newArray[:,1,:]
+            elif self.timebase == 'single':
+                self[()] = newArray[()]
             else:
                 self[:] = newArray[:]
 
@@ -134,6 +136,8 @@ class _function(np.ndarray):
         newArray = self.copy()
         if self.timebase == 'by_time':
             newArray[:,1,:] = operation(self[:,1,:], other)
+        elif self.timebase == 'single':
+            newArray[()] = operation(self, other)
         else:
             newArray[:] = operation(self, other)
         return newArray

--- a/datatypes/_core.py
+++ b/datatypes/_core.py
@@ -83,6 +83,8 @@ class _function(np.ndarray):
         self._operate(other, np.add, inPlace = True)
         return self
 
+    __radd__ = __add__
+    __riadd__ = __iadd__
 
     def __mul__(self, other):
         return self._operate(other, np.multiply, inPlace = False)
@@ -91,6 +93,8 @@ class _function(np.ndarray):
         self._operate(other, np.multiply, inPlace = True)
         return self
 
+    __rmul__ = __mul__
+    __rimul__ = __imul__
 
     def _operate(self, other, operation, inPlace = False):
         if isinstance(other, self.__class__):

--- a/datatypes/beam_data.py
+++ b/datatypes/beam_data.py
@@ -54,7 +54,7 @@ class _beam_data(_function):
     """
     
     def __new__(cls, *args, units, time = None, n_turns = None, 
-                interpolation = 'linear', **kwargs):
+                interpolation = 'linear', dtype=None, **kwargs):
         
         _check_time_turns(time, n_turns)
             
@@ -79,7 +79,8 @@ class _beam_data(_function):
         data_type = {'timebase': data_types[0], 'bunching': bunching,
                      'units': units, **kwargs}
         
-        return super().__new__(cls, data_points, data_type, interpolation)
+        return super().__new__(cls, data_points, data_type, interpolation,
+                               dtype)
 
 
     @property
@@ -154,11 +155,11 @@ class acceptance(_beam_data):
     """
     
     def __new__(cls, *args, units = 'eVs', time = None, n_turns = None, 
-                interpolation = 'linear'):
+                interpolation = 'linear', dtype=None):
         
         return super().__new__(cls, *args, units = units, time = time, 
                                n_turns = n_turns, 
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
 class emittance(_beam_data):
@@ -205,13 +206,14 @@ class emittance(_beam_data):
     """
     
     def __new__(cls, *args, emittance_type = 'matched_area', units = 'eVs', 
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, 
                                emittance_type = emittance_type,
                                units = units, time = time, 
                                n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -275,12 +277,13 @@ class length(_beam_data):
     """
     
     def __new__(cls, *args, length_type = 'full_length', units = 's',
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, length_type = length_type, 
                                units = units, time = time, 
                                n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -343,11 +346,12 @@ class height(_beam_data):
     """
     
     def __new__(cls, *args, height_type = 'half_height', units = 'eV',
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, height_type = height_type, 
                                units = units, time = time, n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -403,8 +407,8 @@ class synchronous_phase(_beam_data):
     """
     
     def __new__(cls, *args, units = 's', time = None, n_turns = None, 
-                interpolation = 'linear'):
+                interpolation = 'linear', dtype=None):
         
         return super().__new__(cls, *args, units = units, time = time, 
                                n_turns = n_turns, 
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)

--- a/datatypes/rf_programs.py
+++ b/datatypes/rf_programs.py
@@ -52,7 +52,8 @@ class _RF_function(_function):
         The harmonics covered by the function.
     """
     def __new__(cls, *args, harmonics, time = None, n_turns = None, \
-                interpolation = 'linear', allow_single = True, **kwargs):
+                interpolation = 'linear', allow_single = True, dtype = None,
+                **kwargs):
 
         args = _expand_function(*args)
 
@@ -82,7 +83,7 @@ class _RF_function(_function):
                      **kwargs}
         
         return super().__new__(cls, data_points, data_type, 
-                               interpolation)
+                               interpolation, dtype)
 
 
     @property

--- a/datatypes/ring_programs.py
+++ b/datatypes/ring_programs.py
@@ -1217,9 +1217,15 @@ class bending_field_program(_synchronous_data_program):
     """A str identifying the data"""
 
 
+
 for data in [momentum_program, total_energy_program, kinetic_energy_program,
              bending_field_program]:
     data._add_to_conversions()
+"""
+Loop over all defined _synchronous_data_program objects and added them to the
+available conversions.
+"""
+
 
 
 class momentum_compaction(_ring_function):

--- a/datatypes/ring_programs.py
+++ b/datatypes/ring_programs.py
@@ -61,7 +61,8 @@ class _ring_function(_function):
 
     """
     def __new__(cls, *args, time=None, n_turns=None,
-                allow_single=False, interpolation=None, **kwargs):
+                allow_single=False, interpolation=None, dtype=None,
+                **kwargs):
         args = _expand_function(*args)
         _check_time_turns(time, n_turns)
 
@@ -85,7 +86,8 @@ class _ring_function(_function):
 
         data_type = {**data_type, **kwargs}
 
-        return super().__new__(cls, data_points, data_type, interpolation)
+        return super().__new__(cls, data_points, data_type, interpolation,
+                               dtype)
 
     @classmethod
     def _combine_single_sections(cls, *args,
@@ -261,9 +263,10 @@ class _synchronous_data_program(_ring_function):
     synchronous programs, and the value is the corresponding class.
     """
 
-    def __new__(cls, *args, time=None, n_turns=None, interpolation=None):
+    def __new__(cls, *args, time=None, n_turns=None, interpolation=None,
+                dtype=None):
         return super().__new__(cls, *args, time=time, n_turns=n_turns,
-                               interpolation=interpolation)
+                               interpolation=interpolation, dtype=dtype)
 
     def to_momentum(self, inPlace=True, **kwargs):
         """
@@ -1256,11 +1259,12 @@ class momentum_compaction(_ring_function):
         The order of the momentum compaction factor program
     """
     def __new__(cls, *args, order=0, time=None, n_turns=None,
-                interpolation='linear'):
+                interpolation='linear', dtype=None):
 
         return super().__new__(cls, *args, time=time,
                                n_turns=n_turns, allow_single=True,
-                               interpolation='linear', order=order)
+                               interpolation='linear', dtype=dtype,
+                               order=order)
 
     @classmethod
     def combine_single_sections(cls, *args, interpolation=None):
@@ -1374,11 +1378,11 @@ class orbit_length_program(_ring_function):
     """
 
     def __new__(cls, *args, time=None, n_turns=None,
-                interpolation='linear'):
+                interpolation='linear', dtype=None):
 
         return super().__new__(cls, *args, time=time,
                                n_turns=n_turns, allow_single=True,
-                               interpolation='linear')
+                               interpolation='linear', dtype=dtype)
 
     @classmethod
     def combine_single_sections(cls, *args, interpolation=None):


### PR DESCRIPTION
- unit tests for _core.py
- functionality for +, +=, *, *= and functionality to add other comparable operators easily
- added `dtype` kwarg throughout to allow specification as float etc
- added `store_time` to `_core._function.reshape`, will work everywhere except in `_RF_function` and subclasses where there is a re-implementation of the function.